### PR TITLE
fix(seed): prevent app-store metadata pass from disabling keyed apps

### DIFF
--- a/packages/prisma/seed-app-store.ts
+++ b/packages/prisma/seed-app-store.ts
@@ -5,6 +5,7 @@
 import type { Prisma } from "@prisma/client";
 import dotEnv from "dotenv";
 
+import { shouldEnableApp } from "@calcom/app-store/_utils/validateAppKeys";
 import { appStoreMetadata } from "@calcom/app-store/appStoreMetaData";
 
 import prisma from ".";
@@ -207,8 +208,11 @@ async function createApp(
       },
     });
 
-    // We need to enable seeded apps as they are used in tests.
-    const data = { slug, dirName, categories, keys, enabled: true };
+    // Preserve existing keys when a later seed pass doesn't provide keys (e.g. appStoreMetadata loop).
+    // Otherwise key-validated apps like google-calendar can be incorrectly disabled.
+    const keysForValidation = (keys ?? foundApp?.keys) as Prisma.JsonValue | undefined;
+    const enabled = shouldEnableApp(dirName, keysForValidation);
+    const data = { slug, dirName, categories, keys, enabled };
 
     if (!foundApp) {
       await prisma.app.create({


### PR DESCRIPTION
## Summary
- keep key-based app enablement stable in `packages/prisma/seed-app-store.ts`
- use existing app keys for validation when a seed pass does not provide new keys
- prevents `google-calendar` / `google-meet` from being flipped to disabled during the metadata loop

## Root Cause
The seed flow creates/updates Google apps with valid keys first, then loops through app metadata and calls `createApp` again without keys. The second call re-evaluated `enabled` against an empty key set and set it to `false`.

## Risk Class
LOW

## Validation Evidence
- lint-staged hooks passed on commit (`prettier --write`, `eslint --fix`)
- code path is narrowly scoped to seed enablement logic
- production symptom matched this bug exactly (`App.enabled=false` for `google-calendar` and `google-meet` despite valid `GOOGLE_API_CREDENTIALS`)

## Rollback Plan
1. Revert this PR.
2. Re-run seed process or manually toggle app enable flags in DB.

## Rollout Notes
- This affects app registration/seed behavior only.
- Existing environments with already-disabled rows need one-time DB correction (already applied to prod/staging during incident handling).
